### PR TITLE
Update SkillLimiter.lua

### DIFF
--- a/Contents/mods/SkillLimiter/media/lua/server/SkillLimiter/SkillLimiter.lua
+++ b/Contents/mods/SkillLimiter/media/lua/server/SkillLimiter/SkillLimiter.lua
@@ -206,12 +206,14 @@ SkillLimiter.getMaxSkill = function(character, perk)
     local character_profession = ProfessionFactory.getProfession(character_profession_str)
 
     -- Go through the XPBoostMap of the profession and add the relevant perk level to the total
-    local profession_xp_boost_map = character_profession:getXPBoostMap()
-    if profession_xp_boost_map then
-        local mapTable = transformIntoKahluaTable(profession_xp_boost_map)
-        for prof_perk, level in pairs(mapTable) do
-            if prof_perk:getId() == perk:getId() then
-                trait_perk_level = trait_perk_level + level:intValue()
+    if character_profession then
+        local profession_xp_boost_map = character_profession:getXPBoostMap()
+        if profession_xp_boost_map then
+            local mapTable = transformIntoKahluaTable(profession_xp_boost_map)
+            for prof_perk, level in pairs(mapTable) do
+                if prof_perk:getId() == perk:getId() then
+                    trait_perk_level = trait_perk_level + level:intValue()
+                end
             end
         end
     end


### PR DESCRIPTION
Only attempt to check the profession xp boost map if a profession was found matching the character_profession_str. This ought to help prevent server logs from being spammed every tick when a mod conflict causes a profession string not to be found.