### PR TITLE
add option to check less often for level-ups

### DIFF
--- a/Contents/mods/SkillLimiter/media/lua/server/SkillLimiter/SkillLimiter.lua
+++ b/Contents/mods/SkillLimiter/media/lua/server/SkillLimiter/SkillLimiter.lua
@@ -298,6 +298,13 @@ local function check_table()
     SkillLimiter.perks_leveled_up = {}
 end
 
+local function check_table_10m()
+    for i, v in ipairs(SkillLimiter.perks_leveled_up) do
+        SkillLimiter.limitSkill(v.character, v.perk, v.level)
+    end
+    SkillLimiter.perks_leveled_up = {}
+end
+
 local function init_check()
     local character = getPlayer()
 
@@ -319,5 +326,12 @@ local function init()
 end
 
 Events.LevelPerk.Add(add_to_table)
-Events.OnTick.Add(check_table)
+
+local checkEveryTenMins = SandboxVars.SkillLimiter.EveryTenMins
+if checkEveryTenMins then 
+    Events.EveryTenMinutes.Add(check_table_10m)
+else
+    Events.OnTick.Add(check_table)
+end
+
 Events.OnTick.Add(init);

--- a/Contents/mods/SkillLimiter/media/lua/shared/Translate/EN/Sandbox_EN.txt
+++ b/Contents/mods/SkillLimiter/media/lua/shared/Translate/EN/Sandbox_EN.txt
@@ -33,4 +33,7 @@ Sandbox_EN = {
 
 	Sandbox_SkillLimiter_PerkBonuses = "Perk Bonuses",
 	Sandbox_SkillLimiter_PerkBonuses_tooltip = "Semicolon separated list of bonuses to add to perks. (e.g. Perk1:1;Perk2:3;Perk3:1)",
+
+	Sandbox_SkillLimiter_EveryTenMins = "Check Every Ten Minutes",
+	Sandbox_SkillLimiter_EveryTenMins_tooltip = "Check for level-ups to limit every ten in-game minutes instead of every tick. Less responsive but more performant.",
 }

--- a/Contents/mods/SkillLimiter/media/sandbox-options.txt
+++ b/Contents/mods/SkillLimiter/media/sandbox-options.txt
@@ -118,3 +118,12 @@ option SkillLimiter.PerkBonuses
     page = SkillLimiter,
     translation = SkillLimiter_PerkBonuses,
 }
+
+option SkillLimiter.EveryTenMins
+{
+    type = boolean,
+    default = false,
+
+    page = SkillLimiter,
+    translation = SkillLimiter_EveryTenMins,
+}


### PR DESCRIPTION
As part of an effort to reduce server load, I'd like to propose this change to make it an option to run the skill limiter less often. 